### PR TITLE
feat: Add reusable ScreenHeading component

### DIFF
--- a/client/src/utilities/ScreenHeading/ScreenHeading.css
+++ b/client/src/utilities/ScreenHeading/ScreenHeading.css
@@ -1,0 +1,42 @@
+.heading-container{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    margin: 0 0 50px 0;
+}
+.screen-sub-heading{
+    letter-spacing: 3px;
+    margin: 8px 0 18px 0;
+    font-size: 12px;
+    color: var(--black);
+}
+.screen-heading{
+    font-size: 32px;
+    color: #1f2235;
+    font-family: "Poppins Bold";
+}
+.heading-separator{
+    display: flex;
+    align-items: center;
+    position: relative;
+    width: 180px;
+    margin: 10px 0 0 0;
+}
+.separator-line{
+    width: 100%;
+    height: 2px;
+    background-color: #1f2235;
+}
+.separator-blob{
+    height: 10px;
+    width: 100%;
+    position: absolute;
+    display: flex;
+    justify-content: center;
+}
+.separator-blob div{
+    width: 35px;
+    border-radius: 10px;
+    background-color: var(--dark-orange);
+}

--- a/client/src/utilities/ScreenHeading/ScreenHeading.js
+++ b/client/src/utilities/ScreenHeading/ScreenHeading.js
@@ -1,0 +1,37 @@
+import React from "react";
+import "./ScreenHeading.css";
+
+/**
+ * Componente ScreenHeading: Componente reusable para encabezados de pantalla.
+ * Renderiza un título principal, un subtítulo opcional y un separador visual.
+ * Diseñado para mantener coherencia visual en los títulos de diferentes secciones de la aplicación.
+ * @param {Object} props - Las propiedades del componente.
+ * @param {string} props.title - El título principal a mostrar (requerido).
+ * @param {string} [props.subHeading] - El subtítulo o descripción opcional.
+ * @returns {JSX.Element} El componente ScreenHeading renderizado.
+ */
+export default function ScreenHeading(props) {
+    return (
+        <div className="heading-container">
+            <div className="screen-heading">
+                <span>{props.title}</span>
+            </div>
+
+            {
+                (props.subHeading) ? (
+                    <div className="screen-sub-heading">
+                        <span>{props.subHeading}</span>
+                    </div>
+                ) : <div></div>
+            }
+
+            <div className="heading-separator">
+                <div className="separator-line">
+                    <div className="separator-blob">
+                        <div></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## Resumen
Esta PR introduce el componente reusable `ScreenHeading` para mantener coherencia visual en los encabezados de las secciones del portfolio. Incluye título, subtítulo opcional y un separador decorativo, con estilos responsivos y documentación JSDoc.

## Cambios Realizados
- **Create reusable component**:
  - Creado `ScreenHeading.js`: Componente React que recibe props `title` (requerido) y `subHeading` (opcional).
  - Renderiza título principal, subtítulo condicional y separador visual.
  - Diseñado para reutilización en múltiples secciones (ej: Home, About Me, etc.).

- **Styling the reusable component**:
  - Creado `ScreenHeading.css`: Estilos para layout centrado, tipografía, colores y separador con línea y blob decorativo.
  - Responsivo básico con márgenes y espaciado consistente.

- **Documentación**: Agregados comentarios JSDoc a `ScreenHeading.js` para explicar props, propósito y retorno.

## ¿Por Qué Este Cambio?
- Promueve reutilización de código y coherencia visual en los títulos de la página.
- Facilita mantenimiento al centralizar el diseño de encabezados.
- Mejora la legibilidad del código con documentación.

## Pruebas
No aplica

## Issues Relacionados
Closes #6 

## Lista de Verificación
- [x] Componente reusable creado y funcional
- [x] Estilos aplicados y consistentes
- [x] JSDoc agregado
- [] Probado en diferentes instancias
- [x] Sin errores de linting
